### PR TITLE
implementation of Types

### DIFF
--- a/R/list-to-tags.R
+++ b/R/list-to-tags.R
@@ -88,9 +88,6 @@ getJSON <- function(node){
   if (!is.null(type)){
     attrib <- c(attrib, paste0("\"type\": \"", type, "\""))
   }
-
-
-  }
   
   paste0("{",paste(attrib, collapse = ","),"}")  
 }

--- a/R/list-to-tags.R
+++ b/R/list-to-tags.R
@@ -1,3 +1,12 @@
+
+fixIconName <- function(icon){
+  if(!is.null(icon)){
+    paste0("fa fa-",icon)
+  }else{
+    NULL
+  }
+}
+
 listToTags <- function(myList, parent=shiny::tags$ul()){
   
   # Handle parent tag attributes
@@ -71,8 +80,16 @@ getJSON <- function(node){
   # Handle 'icon' attribute
   icon <- attr(node, "sticon")
   if (!is.null(icon)){
-    icon <- paste0("fa fa-",icon)
-    attrib <- c(attrib, paste0("\"icon\": \"", icon, "\""))
+    attrib <- c(attrib, paste0("\"icon\": \"", fixIconName(icon), "\""))
+  }
+
+  # Handle 'type' attribute
+  type <- attr(node, "sttype")
+  if (!is.null(type)){
+    attrib <- c(attrib, paste0("\"type\": \"", type, "\""))
+  }
+
+
   }
   
   paste0("{",paste(attrib, collapse = ","),"}")  

--- a/R/shiny-tree.R
+++ b/R/shiny-tree.R
@@ -10,12 +10,13 @@
 #' to the ID of the text input you wish to use as the search field.
 #' @param dragAndDrop If \code{TRUE}, will allow the user to rearrange the nodes in the
 #' tree.
+#' @param types If \code{TRUE}, enables jstree types functionality
 #' @param theme jsTree theme, one of \code{default}, \code{default-dark}, or \code{proton}.
 #' @param themeIcons If \code{TRUE}, will show theme icons for each item.
 #' @param themeDots If \code{TRUE}, will include level dots.
 #' @seealso \code{\link{renderTree}}
 #' @export
-shinyTree <- function(outputId, checkbox=FALSE, search=FALSE, dragAndDrop=FALSE, theme="default", themeIcons=TRUE, themeDots=TRUE){
+shinyTree <- function(outputId, checkbox=FALSE, search=FALSE, dragAndDrop=FALSE, types=NULL,theme="default", themeIcons=TRUE, themeDots=TRUE){
   searchEl <- shiny::div("")
   if (search == TRUE){
     search <- paste0(outputId, "-search-input")
@@ -34,6 +35,10 @@ shinyTree <- function(outputId, checkbox=FALSE, search=FALSE, dragAndDrop=FALSE,
                                type = 'text/css',
                                href = paste('shinyTree/jsTree-3.3.3/themes/',theme,'/style.min.css',sep=""))
   
+  
+  if(!is.null(types)){
+    types <- paste("sttypes =",types)
+  }
   shiny::tagList(
     shiny::singleton(shiny::tags$head(
       initResourcePaths(),
@@ -42,13 +47,15 @@ shinyTree <- function(outputId, checkbox=FALSE, search=FALSE, dragAndDrop=FALSE,
                 type = "text/css", 
                 href = "shared/font-awesome/css/font-awesome.min.css"),
       shiny::tags$script(src = 'shinyTree/jsTree-3.3.3/jstree.min.js'),
-      shiny::tags$script(src = 'shinyTree/shinyTree.js')
+      shiny::tags$script(src = 'shinyTree/shinyTree.js'),
+      shiny::tags$script(HTML(types))
     )),
     searchEl,
     shiny::div(id=outputId, class="shiny-tree", 
         `data-st-checkbox`=checkbox, 
         `data-st-search`=is.character(search),
         `data-st-dnd`=dragAndDrop,
+        `data-st-types`=!is.null(types),
         `data-st-theme`=theme,
         `data-st-theme-icons`=themeIcons,
         `data-st-theme-dots`=themeDots

--- a/R/update-tree.R
+++ b/R/update-tree.R
@@ -25,18 +25,31 @@ Rlist2json <- function(nestedList) {
 
 get_flatList <- function(nestedList, flatList = NULL, parent = "#") {
   for (name in names(nestedList)) {
-    flatList = c(flatList,
-                 list(
-                   list(
-                     id = as.character(length(flatList) + 1),
-                     text = name,
-                     parent = parent,
-                     state = list(
-                       opened   = isTRUE(attr(nestedList[[name]], "stopened")),
-                       selected = isTRUE(attr(nestedList[[name]], "stselected"))
-                     )
-                   )
-                 ))
+    additionalAttributeNames <- c("icon","type")
+    additionalAttributes<- lapply(additionalAttributeNames,function(attribute){
+      if(attribute == "icon"){
+        fixIconName(attr(nestedList[[name]],paste0("st",attribute)))
+      }else{
+        attr(nestedList[[name]],paste0("st",attribute))
+      }
+    })
+    names(additionalAttributes) <-  additionalAttributeNames
+    additionalAttributes <- additionalAttributes[which(sapply(additionalAttributes,Negate(is.null)))]
+
+    nodeData <- append(
+      list(
+        id = as.character(length(flatList) + 1),
+        text = name,
+        parent = parent,
+        state = list(
+          opened   = isTRUE(attr(nestedList[[name]], "stopened")),
+          selected = isTRUE(attr(nestedList[[name]], "stselected"))
+        )
+      ),
+      additionalAttributes
+    )
+
+    flatList = c(flatList,list(nodeData))
     if (is.list(nestedList[[name]]))
       flatList =
         get_flatList(nestedList[[name]], flatList, parent = as.character(length(flatList)))

--- a/inst/examples/12-types/server.R
+++ b/inst/examples/12-types/server.R
@@ -1,0 +1,36 @@
+library(shiny)
+library(shinyTree)
+
+#' Examples of using jstree types to define node attributes
+#' @author Michael Bell \email{bellma@@lilly.com}
+shinyServer(function(input, output, session) {
+  log <- c(paste0(Sys.time(), ": Interact with the tree to see the logs here..."))
+  
+  treeData <- reactive({
+    list(
+      root1 = structure("", stselected=TRUE,sttype="root"),
+      root2 = structure(list(
+        SubListA = structure(list(
+            leaf1 = structure("",sttype="file"), 
+            leaf2 = structure("",sttype="file"),
+            leaf3 = structure("",sttype="file")),
+            sttype="root",stopened=TRUE
+            ),
+        SubListB = structure(list(
+          leafA = structure("",sttype="file"),
+          leafB = structure("",sttype="file")
+          ),stopened=TRUE,sttype="root")
+      ),
+      sttype="root",stopened=TRUE
+    )
+  )
+  })
+  
+  observeEvent(input$updateTree,{
+    updateTree(session, treeId = "tree", data = treeData())
+  })
+  
+  output$tree <- renderTree({
+    treeData()
+  })
+})

--- a/inst/examples/12-types/ui.R
+++ b/inst/examples/12-types/ui.R
@@ -1,0 +1,28 @@
+library(shiny)
+library(shinyTree)
+
+#' Demonstrates types
+#' @author Michael Bell \email{bellma@@lilly.com}
+shinyUI(
+  pageWithSidebar(
+    # Application title
+    headerPanel("shinyTree with types!"),
+    
+    sidebarPanel(
+      helpText(HTML("A shinyTree example using types to dictate the behavior of specific nodes.
+                  <hr>Created using shinyTree<hr>Update button exists to make sure the output of the update tree is the same as renderTree</a>.")),
+      actionButton(inputId = "renderTree", "render"),
+      actionButton(inputId = "updateTree", "update")
+    ),
+    mainPanel(
+      # Show a simple table.
+      shinyTree("tree", dragAndDrop = TRUE,types= #Types is in the same formate that jstree expects
+      "{
+          '#': { 'max_children' : 2, 'max_depth' : 4, 'valid_children' : ['root'] },
+          'root' : { 'icon' : 'fa fa-signal', 'valid_children' : ['file'] },
+          'default' : { 'valid_children' : ['default','file'] },
+          'file' : { 'icon' : 'glyphicon glyphicon-file', 'valid_children' : [] }
+        }"
+      )
+    )
+  ))

--- a/inst/www/shinyTree.js
+++ b/inst/www/shinyTree.js
@@ -1,4 +1,5 @@
 var shinyTree = function(){
+  sttypes = null;
 
   var treeOutput = new Shiny.OutputBinding();
   $.extend(treeOutput, {

--- a/inst/www/shinyTree.js
+++ b/inst/www/shinyTree.js
@@ -22,11 +22,16 @@ var shinyTree = function(){
       if ($elem.data('st-dnd') === 'TRUE'){
         plugins.push('dnd');
       }
+      if ($elem.data('st-types') === 'TRUE'){
+        plugins.push('types');
+      }
       
-      var tree = $(el).jstree({'core' : {
-        "check_callback" : ($elem.data('st-dnd') === 'TRUE'),
+      var tree = $(el).jstree({'core' : { 
+        "check_callback" : ($elem.data('st-dnd') === 'TRUE'), 
         'themes': {'name': $elem.data('st-theme'), 'responsive': true, 'icons': ($elem.data('st-theme-icons') === 'TRUE'), 'dots': ($elem.data('st-theme-dots') === 'TRUE') }
-      },plugins: plugins});
+          },
+          "types" : sttypes,
+          plugins: plugins});
     }
   });
   Shiny.outputBindings.register(treeOutput, 'shinyTree.treeOutput');


### PR DESCRIPTION
Hi, 

This pull request implements jstree types. Types are passed in jstree format:
shinyTree("tree", dragAndDrop = TRUE,types= #Types is in the same formate that jstree expects
      "{
          '#': { 'max_children' : 2, 'max_depth' : 4, 'valid_children' : ['root'] },
          'root' : { 'icon' : 'fa fa-signal', 'valid_children' : ['file'] },
          'default' : { 'valid_children' : ['default','file'] },
          'file' : { 'icon' : 'glyphicon glyphicon-file', 'valid_children' : [] }
        }"
      )

Then, they can be used like so:
list(
      root1 = structure("", stselected=TRUE,sttype="root"),
...

An example "12-types" is included.
I don't expect that this is a perfect implementation, but I hope it starts on the road.

 (it also fixes a bug where icons were ignored in updateTree)